### PR TITLE
Zod input output

### DIFF
--- a/.changeset/ninety-starfishes-taste.md
+++ b/.changeset/ninety-starfishes-taste.md
@@ -1,0 +1,5 @@
+---
+"next-typesafe-url": minor
+---
+
+correctly infers zod inputs and outputs, mainly affects using `$path` with zod coercion/transform. Now exposes seperate `RouterInputs` and `RouterOutputs` types to account for this change

--- a/examples/appdir/next-typesafe-url.d.ts
+++ b/examples/appdir/next-typesafe-url.d.ts
@@ -10,8 +10,9 @@ import { type RouteType as Route_0 } from "./src/app/(test)/foo/[id]/nest/routeT
 import { type RouteType as Route_1 } from "./src/app/(test)/foo/[id]/routeType";
 import { type RouteType as Route_2 } from "./src/app/client/[...client]/routeType";
 import { type RouteType as Route_3 } from "./src/app/jsonRoute/[foo]/routeType";
-import { type RouteType as Route_4 } from "./src/app/[slug]/[...foo]/routeType";
-import { type RouteType as Route_5 } from "./src/pages/dynamic";
+import { type RouteType as Route_4 } from "./src/app/transform/routeType";
+import { type RouteType as Route_5 } from "./src/app/[slug]/[...foo]/routeType";
+import { type RouteType as Route_6 } from "./src/pages/dynamic";
 import type { InferRoute, StaticRoute } from "next-typesafe-url";
 
 declare module "@@@next-typesafe-url" {
@@ -20,8 +21,9 @@ declare module "@@@next-typesafe-url" {
     "/foo/[id]": InferRoute<Route_1>;
     "/client/[...client]": InferRoute<Route_2>;
     "/jsonRoute/[foo]": InferRoute<Route_3>;
-    "/[slug]/[...foo]": InferRoute<Route_4>;
-    "/dynamic": InferRoute<Route_5>;
+    "/transform": InferRoute<Route_4>;
+    "/[slug]/[...foo]": InferRoute<Route_5>;
+    "/dynamic": InferRoute<Route_6>;
   }
 
   interface StaticRouter {

--- a/examples/appdir/src/app/page.tsx
+++ b/examples/appdir/src/app/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { $path, type AppRouter } from "next-typesafe-url";
+import { $path, type RouterOutputs } from "next-typesafe-url";
 import Link from "next/link";
 
-type _ThisIsHelpful = AppRouter["/[slug]/[...foo]"]["routeParams"];
+type _ThisIsHelpful = RouterOutputs["/[slug]/[...foo]"]["routeParams"];
 
 export default function Page() {
   return (

--- a/examples/appdir/src/app/transform/page.tsx
+++ b/examples/appdir/src/app/transform/page.tsx
@@ -1,0 +1,30 @@
+import { withParamValidation } from "next-typesafe-url/app";
+import {
+  $path,
+  type InferPagePropsType,
+  type RouterInputs,
+  type RouterOutputs,
+} from "next-typesafe-url";
+import { Route, RouteType } from "./routeType";
+
+type _TestInput = RouterInputs["/transform"];
+type _TestOutput = RouterOutputs["/transform"];
+
+type PageProps = InferPagePropsType<RouteType>;
+
+const Page = ({ searchParams }: PageProps) => {
+  const _test = $path({
+    route: "/transform",
+    searchParams: {
+      foo: 5,
+    },
+  });
+
+  return (
+    <>
+      <div>{`data: ${JSON.stringify(searchParams)}`}</div>
+    </>
+  );
+};
+
+export default withParamValidation(Page, Route);

--- a/examples/appdir/src/app/transform/routeType.ts
+++ b/examples/appdir/src/app/transform/routeType.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { type DynamicRoute } from "next-typesafe-url";
+
+export const Route = {
+  searchParams: z.object({
+    foo: z.number().transform((val) => `${val}`),
+  }),
+} satisfies DynamicRoute;
+
+export type RouteType = typeof Route;

--- a/examples/pagesdir/src/pages/[slug]/server.tsx
+++ b/examples/pagesdir/src/pages/[slug]/server.tsx
@@ -4,7 +4,7 @@ import type {
   GetServerSideProps,
 } from "next";
 import { z } from "zod";
-import { $path, type AppRouter } from "next-typesafe-url";
+import { $path, type RouterOutputs } from "next-typesafe-url";
 import {
   parseServerSideRouteParams,
   parseServerSideSearchParams,
@@ -21,8 +21,8 @@ const Route = {
 };
 export type RouteType = typeof Route;
 
-type ServerSideProps = AppRouter["/[slug]/server"]["searchParams"] &
-  AppRouter["/[slug]/server"]["routeParams"];
+type ServerSideProps = RouterOutputs["/[slug]/server"]["searchParams"] &
+  RouterOutputs["/[slug]/server"]["routeParams"];
 
 export const getServerSideProps: GetServerSideProps<ServerSideProps> = async ({
   query,

--- a/packages/next-typesafe-url/src/app.ts
+++ b/packages/next-typesafe-url/src/app.ts
@@ -36,7 +36,7 @@ export function useRouteParams<T extends z.AnyZodObject>(
   const same = JSON.stringify(prev) === JSON.stringify(params);
   const [isError, setIsError] = useState(false);
   const [error, setError] = useState<z.ZodError>(new z.ZodError([]));
-  const [data, setData] = useState<z.infer<T> | undefined>(undefined);
+  const [data, setData] = useState<z.output<T> | undefined>(undefined);
 
   useEffect(() => {
     const parsedRouteParams = parseObjectFromUseParams(params);
@@ -84,7 +84,7 @@ export function useSearchParams<T extends z.AnyZodObject>(
   const params = useNextSearchParams();
   const [isError, setIsError] = useState(false);
   const [error, setError] = useState<z.ZodError>(new z.ZodError([]));
-  const [data, setData] = useState<z.infer<T> | undefined>(undefined);
+  const [data, setData] = useState<z.output<T> | undefined>(undefined);
 
   useEffect(() => {
     const parsedSearchParams = parseObjectFromReadonlyURLParams(params);

--- a/packages/next-typesafe-url/src/index.ts
+++ b/packages/next-typesafe-url/src/index.ts
@@ -7,7 +7,8 @@ import {
 import type {
   AllRoutes,
   PathOptions,
-  AppRouter,
+  RouterInputs,
+  RouterOutputs,
   InferRoute,
   DynamicRoute,
   InferPagePropsType,
@@ -21,7 +22,8 @@ import type {
 export type {
   AllRoutes,
   PathOptions,
-  AppRouter,
+  RouterInputs,
+  RouterOutputs,
   InferRoute,
   DynamicRoute,
   InferPagePropsType,

--- a/packages/next-typesafe-url/src/pages.ts
+++ b/packages/next-typesafe-url/src/pages.ts
@@ -18,7 +18,7 @@ export function useRouteParams<T extends z.AnyZodObject>(
   const router = useRouter();
   const [isError, setIsError] = useState(false);
   const [error, setError] = useState<z.ZodError>(new z.ZodError([]));
-  const [data, setData] = useState<z.infer<T> | undefined>(undefined);
+  const [data, setData] = useState<z.output<T> | undefined>(undefined);
 
   useEffect(() => {
     if (router.isReady) {
@@ -66,7 +66,7 @@ export function useSearchParams<T extends z.AnyZodObject>(
   const router = useRouter();
   const [isError, setIsError] = useState(false);
   const [error, setError] = useState<z.ZodError>(new z.ZodError([]));
-  const [data, setData] = useState<z.infer<T> | undefined>(undefined);
+  const [data, setData] = useState<z.output<T> | undefined>(undefined);
 
   useEffect(() => {
     if (router.isReady) {

--- a/packages/next-typesafe-url/src/types.d.ts
+++ b/packages/next-typesafe-url/src/types.d.ts
@@ -3,19 +3,39 @@ import { z } from "zod";
 
 type AppRouter = StaticRouter & DynamicRouter;
 
+type RouterInputs = {
+  [K in keyof AppRouter]: AppRouter[K]["input"];
+};
+
+type RouterOutputs = {
+  [K in keyof AppRouter]: AppRouter[K]["output"];
+};
+
 type StaticRoutes = keyof StaticRouter;
 type DynamicRoutes = keyof DynamicRouter;
 
-type InferRoute<T extends DynamicRoute> = HandleUndefined<Helper<T>>;
+type InferRoute<T extends DynamicRoute> = {
+  input: HandleUndefined<HelperInput<T>>;
+  output: HandleUndefined<HelperOutput<T>>;
+};
 
 type HasProperty<T, K extends string> = K extends keyof T ? true : false;
 
-type Helper<T extends DynamicRoute> = {
+type HelperInput<T extends DynamicRoute> = {
   searchParams: HasProperty<T, "searchParams"> extends true
-    ? z.infer<T["searchParams"]>
+    ? z.input<T["searchParams"]>
     : undefined;
   routeParams: HasProperty<T, "routeParams"> extends true
-    ? z.infer<T["routeParams"]>
+    ? z.input<T["routeParams"]>
+    : undefined;
+};
+
+type HelperOutput<T extends DynamicRoute> = {
+  searchParams: HasProperty<T, "searchParams"> extends true
+    ? z.output<T["searchParams"]>
+    : undefined;
+  routeParams: HasProperty<T, "routeParams"> extends true
+    ? z.output<T["routeParams"]>
     : undefined;
 };
 
@@ -79,13 +99,13 @@ type DynamicRoute = {
 type DynamicLayout = Required<Pick<DynamicRoute, "routeParams">>;
 
 type InferLayoutPropsType<T extends DynamicLayout, K extends string = never> = {
-  routeParams: z.infer<T["routeParams"]>;
+  routeParams: z.output<T["routeParams"]>;
   children: React.ReactNode;
 } & { [P in K]: React.ReactNode };
 
 type PathOptions<T extends AllRoutes> = T extends StaticRoutes
   ? StaticPathOptions<T>
-  : { route: T } & AppRouter[T];
+  : { route: T } & RouterInputs[T];
 
 type AllPossiblyUndefined<T> = Exclude<Partial<T>, undefined> extends T
   ? undefined
@@ -107,7 +127,7 @@ type UseParamsResult<T extends z.AnyZodObject> =
       error: undefined;
     }
   | {
-      data: z.infer<T>;
+      data: z.output<T>;
       isError: false;
       isLoading: false;
       error: undefined;
@@ -121,7 +141,7 @@ type UseParamsResult<T extends z.AnyZodObject> =
 
 type ServerParseParamsResult<T extends z.AnyZodObject> =
   | {
-      data: z.infer<T>;
+      data: z.output<T>;
       isError: false;
       error: undefined;
     }
@@ -133,16 +153,17 @@ type ServerParseParamsResult<T extends z.AnyZodObject> =
 
 type InferPagePropsType<T extends DynamicRoute> = {
   searchParams: T["searchParams"] extends z.AnyZodObject
-    ? z.infer<T["searchParams"]>
+    ? z.output<T["searchParams"]>
     : undefined;
   routeParams: T["routeParams"] extends z.AnyZodObject
-    ? z.infer<T["routeParams"]>
+    ? z.output<T["routeParams"]>
     : undefined;
 };
 
 export {
   // shared types
-  AppRouter,
+  RouterInputs,
+  RouterOutputs,
   AllRoutes,
   DynamicRoute,
 

--- a/www/docs/src/content/docs/en/api-reference.md
+++ b/www/docs/src/content/docs/en/api-reference.md
@@ -31,17 +31,40 @@ type StaticRoute = {
 };
 ```
 
-### `AppRouter`
+### `RouterInputs`
+
+The input types of the zod schema for each of the routes in your app.
 
 ```ts
-type __Routes = "/" | "/foo"; // ... all of the routes in your app
-type AppRouter = Record<__Routes, DynamicRoute | StaticRoute>;
+type __AllRoutes = "/" | "/foo"; // ... all of the routes in your app
+type RouterInputs = Record<
+  __AllRoutes,
+  InferZodInput<DynamicRoute> | StaticRoute
+>;
 ```
 
 Usage:
 
 ```ts
-type FooSearchParams = AppRouter["/foo"]["searchParams"];
+type FooSearchParamsInput = RouterInputs["/foo"]["searchParams"];
+```
+
+### `RouterOutputs`
+
+The outputtypes of the zod schema for each of the routes in your app.
+
+```ts
+type __AllRoutes = "/" | "/foo"; // ... all of the routes in your app
+type RouterOutputs = Record<
+  __AllRoutes,
+  InferZodOutput<DynamicRoute> | StaticRoute
+>;
+```
+
+Usage:
+
+```ts
+type FooSearchParams = RouterOutputs["/foo"]["searchParams"];
 ```
 
 ### `AllRoutes`
@@ -116,7 +139,7 @@ type InferLayoutPropsType<T extends DynamicLayout, K extends string = never> = {
 Provides the input type for `$path` but could be useful for other things.
 
 ```ts
-type PathOptions<T extends AllRoutes> = { route: T } & AppRouter[T];
+type PathOptions<T extends AllRoutes> = { route: T } & RouterInputs[T];
 ```
 
 ### `$path`


### PR DESCRIPTION
correctly infers zod inputs and outputs, mainly affects using $path with zod coercion/transform. Now exposes seperate RouterInputs and RouterOutputs types to account for this change