### PR TITLE
feat: remove whitespace from infoText

### DIFF
--- a/.changeset/red-ties-hide.md
+++ b/.changeset/red-ties-hide.md
@@ -1,0 +1,5 @@
+---
+"next-typesafe-url": patch
+---
+
+Remove empty first line in the auto-generated file

--- a/packages/next-typesafe-url/src/generateTypes.ts
+++ b/packages/next-typesafe-url/src/generateTypes.ts
@@ -173,7 +173,7 @@ export function generateTypesFile({
     .map((route) => `  "${route}": StaticRoute;`)
     .join("\n  ");
 
-  const fileContentString = `${infoText}\n${importStatements.join("\n")}
+  const fileContentString = `${infoText.trim()}\n${importStatements.join("\n")}
 
 declare module "@@@next-typesafe-url" {
   interface DynamicRouter {


### PR DESCRIPTION
This removes the empty first line in the auto-generated file which causes some linter configs to throw an error. This simple (1 line) change does not affect any of the package's functionality, it just makes some people's lives that has to follow a particular linter config a lot easier. 