### PR TITLE
fix: documentation typos

### DIFF
--- a/www/docs/src/content/docs/en/general/motivations.md
+++ b/www/docs/src/content/docs/en/general/motivations.md
@@ -6,7 +6,7 @@ nextPage:
   link: "en/general/installation"
 ---
 
-## Whats wrong with curent solutions?
+## Whats wrong with current solutions?
 
 ### Routing
 

--- a/www/docs/src/content/docs/en/setup/defining-your-routes.md
+++ b/www/docs/src/content/docs/en/setup/defining-your-routes.md
@@ -89,7 +89,7 @@ const Route = {
 
 If you want search params or a optional catch-all route param to be optional, use `.optional()` on the zod type.
 
-**Don't make the top level zod objects optional**, if you wan't to make it so a route could _optionally_ take no search params or route params, then simply make each item inside the zod object optional, and `next-typesafe-url` will automatically infer the whole object as optional.
+**Don't make the top level zod objects optional**, if you want to make it so a route could _optionally_ take no search params or route params, then simply make each item inside the zod object optional, and `next-typesafe-url` will automatically infer the whole object as optional.
 
 ```ts
 export const Route = {

--- a/www/docs/src/content/docs/en/usage/search-route-params-pages.md
+++ b/www/docs/src/content/docs/en/usage/search-route-params-pages.md
@@ -50,7 +50,7 @@ export default function Component() {
 
 <h4>MAKE SURE YOU IMPORT FROM THE RIGHT PATH</h4>
 
-## Reccomended Usage
+## Recommended Usage
 
 As I mentioned earlier, it is important that only the `RouteType`, not the `Route` is exported to not break hot reloading.
 


### PR DESCRIPTION
Fixed typos that I noticed while reading through the docs.