### PR TITLE
fix: update `SomeReactComponent` type

### DIFF
--- a/packages/next-typesafe-url/src/app/hoc.tsx
+++ b/packages/next-typesafe-url/src/app/hoc.tsx
@@ -10,7 +10,8 @@ type NextAppPageProps = {
 } & Record<string, unknown>;
 
 type SomeReactComponent = (
-  ...args: unknown[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- describing a generic component
+  ...args: any[]
 ) => ReactNode | Promise<ReactNode>;
 
 /**

--- a/packages/next-typesafe-url/src/app/hoc.tsx
+++ b/packages/next-typesafe-url/src/app/hoc.tsx
@@ -1,6 +1,6 @@
+import type { ReactElement, ReactNode } from "react";
 import { parseServerSideParams } from "../utils";
 import type { DynamicRoute, DynamicLayout } from "../types";
-import { type ReactElement } from "react";
 
 // the props passed to a page component by Next.js
 // https://nextjs.org/docs/app/api-reference/file-conventions/page
@@ -10,9 +10,8 @@ type NextAppPageProps = {
 } & Record<string, unknown>;
 
 type SomeReactComponent = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- describing a generic component
-  ...args: any[]
-) => JSX.Element | Promise<JSX.Element>;
+  ...args: unknown[]
+) => ReactNode | Promise<ReactNode>;
 
 /**
  * A HOC that validates the params passed to a page component.


### PR DESCRIPTION
## Description
This PR updates the `SomeReactComponent` type to include all of the things that are accepted in a `React.FunctionComponent` (or `React.FC`) type.

## Before
Currently, if someone were to use the `withParamValidation` or `withLayoutParamValidation` HOC on a React component manually annotated with `React.FC`, such as:
```tsx
import type React from "react";
import { withParamValidation, type InferPagePropsType } from "next-typesafe-url";

import { route } from "./routeType";

const SomePage: React.FC<InferPagePropsType<typeof route>> = () => null;

export default withParamValidation(SomePage, route);
```

TypeScript will throw an error.
```
Argument of type 'FunctionComponent<InferPagePropsType<{ ... }>> & { ...; }' is not assignable to parameter of type 'SomeReactComponent'.
  Type 'ReactNode' is not assignable to type 'Element | Promise<Element>'.
    Type 'undefined' is not assignable to type 'Element | Promise<Element>'.ts(2345)
```

## After
TypeScript will no longer show the previous error.