### PR TITLE
fix: reset error state

### DIFF
--- a/.changeset/lemon-rings-attack.md
+++ b/.changeset/lemon-rings-attack.md
@@ -1,0 +1,5 @@
+---
+"next-typesafe-url": patch
+---
+
+Fixed page useRouteParams error status not reset issue.

--- a/packages/next-typesafe-url/src/pages.ts
+++ b/packages/next-typesafe-url/src/pages.ts
@@ -39,6 +39,7 @@ export function useRouteParams<T extends z.AnyZodObject>(
       const validatedDynamicRouteParams = validator.safeParse(dynamicParams);
       // update state based on the validation result
       if (validatedDynamicRouteParams.success) {
+        setIsError(false);
         setData(validatedDynamicRouteParams.data);
       } else {
         setIsError(true);


### PR DESCRIPTION
## This PR:
<!-- describe what changes were made -->

reset the error state for page useRouteParams hook.

step to reproduce issue:

1. visit a invalid route
2. write a hook with useEffect, which replace current invalid route to default route
3. isError will still true, error still exist

 - [x] Yes I have made a changeset

<!-- make sure you made a change set!! -->

<!-- thank you for your contribution -->
