### PR TITLE
fix: Use `Validator` instead of `DynamicLayout`

### DIFF
--- a/.changeset/khaki-rules-look.md
+++ b/.changeset/khaki-rules-look.md
@@ -1,0 +1,5 @@
+---
+"next-typesafe-url": patch
+---
+
+Adjust `withLayoutParamValidation` typings so that users don't have to specify generics manually

--- a/packages/next-typesafe-url/src/app/hoc.tsx
+++ b/packages/next-typesafe-url/src/app/hoc.tsx
@@ -127,7 +127,7 @@ export function withLayoutParamValidation<
   Component: (
     props: InferLayoutPropsType<Validator, AdditionalKeys>,
   ) => ReactNode | Promise<ReactNode>,
-  validator: DynamicLayout,
+  validator: Validator,
 ): (props: NextAppLayoutProps<AdditionalKeys>) => JSX.Element {
   // the new component that will be returned
   const ValidatedLayoutComponent = (


### PR DESCRIPTION
## This PR: 

Adjusts `withLayoutParamValidation` typings so that users don't have to specify generics manually

<!-- describe what changes were made -->

- [x] (if ready to be merged) Yes I have made a changeset

<!-- make sure you made a change set!! -->

<!-- thank you for your contribution -->
