### PR TITLE
Handle underscores escaped as `%5F`

### DIFF
--- a/.changeset/fuzzy-masks-give.md
+++ b/.changeset/fuzzy-masks-give.md
@@ -1,0 +1,5 @@
+---
+"next-typesafe-url": patch
+---
+
+Handle underscores escaped as %5F

--- a/examples/appdir/_next-typesafe-url_.d.ts
+++ b/examples/appdir/_next-typesafe-url_.d.ts
@@ -7,8 +7,9 @@
 
 declare module "@@@next-typesafe-url" {
   import type { InferRoute, StaticRoute } from "next-typesafe-url";
-  
+
   interface DynamicRouter {
+    "/_internal/__very-internal/[slug]": InferRoute<import("./src/app/%5Finternal/%5F%5Fvery-internal/[slug]/routeType").RouteType>;
     "/foo/[id]/nest": InferRoute<import("./src/app/(test)/foo/[id]/nest/routeType").RouteType>;
     "/foo/[id]": InferRoute<import("./src/app/(test)/foo/[id]/routeType").RouteType>;
     "/[slug]/[...foo]": InferRoute<import("./src/app/[slug]/[...foo]/routeType").RouteType>;
@@ -19,6 +20,7 @@ declare module "@@@next-typesafe-url" {
   }
 
   interface StaticRouter {
+    "/_internal/__very-internal": StaticRoute;
     "/": StaticRoute;
     "/bar": StaticRoute;
     "/mdx-route": StaticRoute;

--- a/examples/appdir/src/app/%5Finternal/%5F%5Fvery-internal/[slug]/page.tsx
+++ b/examples/appdir/src/app/%5Finternal/%5F%5Fvery-internal/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import { withParamValidation } from "next-typesafe-url/app/hoc";
+import { InferPagePropsType } from "next-typesafe-url";
+import { Route, RouteType } from "./routeType";
+import { Suspense } from "react";
+
+type PageProps = InferPagePropsType<RouteType>;
+
+const Inner = async ({ routeParams }: PageProps) => {
+  const params = await routeParams;
+  console.log(JSON.stringify(params));
+
+  return <div>{`data: ${JSON.stringify(params)}`}</div>;
+};
+const Page = (props: PageProps) => {
+  return (
+    <Suspense>
+      <Inner {...props} />
+    </Suspense>
+  );
+};
+
+export default withParamValidation(Page, Route);

--- a/examples/appdir/src/app/%5Finternal/%5F%5Fvery-internal/[slug]/routeType.ts
+++ b/examples/appdir/src/app/%5Finternal/%5F%5Fvery-internal/[slug]/routeType.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { type DynamicRoute } from "next-typesafe-url";
+
+export const Route = {
+  routeParams: z.object({
+    slug: z.string(),
+  }),
+} satisfies DynamicRoute;
+
+export type RouteType = typeof Route;

--- a/examples/appdir/src/app/%5Finternal/%5F%5Fvery-internal/page.tsx
+++ b/examples/appdir/src/app/%5Finternal/%5F%5Fvery-internal/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>hello</div>;
+}

--- a/packages/next-typesafe-url/src/generateTypes.ts
+++ b/packages/next-typesafe-url/src/generateTypes.ts
@@ -232,7 +232,7 @@ declare module "@@@next-typesafe-url" {
 
 // Helper function to normalize routes by replacing `%5F` with `_`.
 //
-// From the Next.js docs:
+// From the Next.js docs (https://nextjs.org/docs/app/getting-started/project-structure):
 // ```
 // You can create URL segments that start with an underscore by prefixing
 // the folder name with %5F (the URL-encoded form of an underscore): %5FfolderName.

--- a/packages/next-typesafe-url/src/generateTypes.ts
+++ b/packages/next-typesafe-url/src/generateTypes.ts
@@ -185,7 +185,7 @@ export function generateTypesFile({
 
       const pathAfterSrc = path.join(
         type,
-        route === "/" ? "" : route,
+        rawRoute === "/" ? "" : rawRoute,
         type === "app" ? filename : "",
       );
 


### PR DESCRIPTION
## This PR:

Handles underscores in paths escaped as `%5F`, as per Next.js docs:

<img width="659" alt="image" src="https://github.com/user-attachments/assets/e100e91f-2efd-4d10-80ce-e2ae8013afd9" />

https://nextjs.org/docs/app/getting-started/project-structure

- [x] Unescape `%5F` as `_` for generated routes.
- [x] Preserve `%5F` as is for filesystem paths.
- [x] (if ready to be merged) Yes I have made a changeset

