### PR TITLE
fix(app-router): correct param type inference in withParamValidation for Next.js 15

### DIFF
--- a/packages/next-typesafe-url/src/app/hoc.tsx
+++ b/packages/next-typesafe-url/src/app/hoc.tsx
@@ -10,10 +10,10 @@ import type {
 // the props passed to a page component by Next.js
 // https://nextjs.org/docs/app/api-reference/file-conventions/page
 type NextAppPageProps = {
-  params: Promise<Record<string, string | string[]>> | Record<string, string>;
+  params: Promise<Record<string, string | string[]>>;
   searchParams:
-    | Promise<{ [key: string]: string | string[] | undefined }>
-    | { [key: string]: string | string[] | undefined };
+     Promise<{ [key: string]: string | string[] | undefined }>
+   ;
   // [key: string]: unknown;
 };
 


### PR DESCRIPTION


## This PR:

Issue: #134 
Removed non promise based types from params and searchParams for type 'NextAppPageProps' in hoc.tsx


