### PR TITLE
fix: page extensions are used if passed

### DIFF
--- a/.changeset/funny-experts-play.md
+++ b/.changeset/funny-experts-play.md
@@ -1,0 +1,5 @@
+---
+"next-typesafe-url": patch
+---
+
+pageExtensions are taken into account when passed

--- a/packages/next-typesafe-url/src/generateTypes.ts
+++ b/packages/next-typesafe-url/src/generateTypes.ts
@@ -44,11 +44,12 @@ export function getPAGESRoutesWithExportedRoute({
         fileContent,
       );
 
+      const extPattern = pageExtensions.join("|");
       let routePath = fullPath
         .replace(basePath, "")
         .replace(/\\/g, "/")
-        .replace(/\/index\.(tsx|js)$/, "")
-        .replace(/\.(tsx|js)$/, "");
+        .replace(new RegExp(`\\/index\\.(${extPattern})$`), "")
+        .replace(new RegExp(`\\.(${extPattern})$`), "");
 
       // Matches all the index files with extensions from the pageExtensions
       if (pageExtensions.map((ext) => `index.${ext}`).includes(fileName)) {


### PR DESCRIPTION
## This PR:

Page extensions aren't honored if passed

- [x] (if ready to be merged) Yes I have made a changeset

<!-- make sure you made a change set!! -->

<!-- thank you for your contribution -->
